### PR TITLE
Fix argument naming from --step to --steps in eval.sh and main.py

### DIFF
--- a/eval.sh
+++ b/eval.sh
@@ -111,7 +111,7 @@ for prompt in "${PROMPTS[@]}"; do
       --negative_prompt "$NEGATIVE_PROMPT" \
       --loss_type "$LOSS" \
       --guidance_scale "$GUIDANCE" \
-      --step "$STEPS" \
+      --steps "$STEPS" \
       --lr "$LR" \
       --device "$DEVICE" \
       --save_dir "$SAVE_DIR" \
@@ -124,7 +124,7 @@ for prompt in "${PROMPTS[@]}"; do
       --negative_prompt "$NEGATIVE_PROMPT" \
       --loss_type "$LOSS" \
       --guidance_scale "$GUIDANCE" \
-      --step "$STEPS" \
+      --steps "$STEPS" \
       --lr "$LR" \
       --device "$DEVICE" \
       --save_dir "$SAVE_DIR" \
@@ -138,7 +138,7 @@ for prompt in "${PROMPTS[@]}"; do
       --negative_prompt "$NEGATIVE_PROMPT" \
       --loss_type "$LOSS" \
       --guidance_scale "$GUIDANCE" \
-      --step "$STEPS" \
+      --steps "$STEPS" \
       --lr "$LR" \
       --device "$DEVICE" \
       --save_dir "$SAVE_DIR"

--- a/main.py
+++ b/main.py
@@ -47,8 +47,8 @@ def run(args):
     model = init_model(args)
     device = model.device
     guidance_scale = args.guidance_scale
-    steps = args.step
-    
+    steps = args.steps
+
     # Get text embeddings
     cond_embeddings = model.get_text_embeds(args.prompt)
     uncond_embeddings = model.get_text_embeds(args.negative_prompt)
@@ -142,8 +142,8 @@ def parse_args():
     
     parser.add_argument("--loss_type", type=str, default="sds", choices=["sds", "sdi", "vsd"])
     parser.add_argument("--guidance_scale", type=float, default=7.5)
-    parser.add_argument("--step", type=int, default=500)
-    
+    parser.add_argument("--steps", type=int, default=500)
+
     parser.add_argument("--device", type=int, default=0)
     parser.add_argument("--lr", type=float, default=0.01, help="Learning rate for latents (default: 0.01)")
     
@@ -190,8 +190,8 @@ def main():
     print(f"[*] Prompt: {args.prompt}")
     print(f"[*] Guidance scale: {args.guidance_scale}")
     print(f"[*] Learning rate: {args.lr}")
-    print(f"[*] Steps: {args.step}")
-    
+    print(f"[*] Steps: {args.steps}")
+
     if args.loss_type == "sdi":
         print(f"[*] SDI Parameters:")
         print(f"    - Update interval: every {args.sdi_update_interval} steps")


### PR DESCRIPTION
When working on **Task 3 — Score Distillation via Inversion (SDI)**, I encountered an issue with the `steps` argument.

The command in README.md uses:

```bash
python main.py --prompt "${PROMPT}" --loss_type sdi --lr 0.005 --steps 1000 --guidance_scale 7.5 \
               --inversion_n_steps 10 --inversion_guidance_scale -7.5 \
               --inversion_eta 0.3 --sdi_update_interval 25
```

However, in `main.py`, the parser expects the argument as `--step` (singular) instead of `--steps`. This mismatch causes an argument error.

To resolve this, I updated the code to use `--steps` consistently to match the usage in `eval.sh`. I’m submitting this PR to align the naming and prevent confusion for future users.

This inconsistency causes argparse to throw an error when following the README or eval.sh, which may confuse new users.
To ensure consistency and avoid runtime errors, I aligned the argument name to --steps across the codebase.

Just a tiny bug fix — nothing fancy 😆
